### PR TITLE
Add WICHRUNTIME env var to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,9 @@ fi
 # get the directory contains this script
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
+# environment variables
+export WICHRUNTIME=$DIR
+
 # make install the project
 BUILD_DIR=/tmp/wich-build/
 SAMPLE_DIR=$BUILD_DIR/malloc/samples/


### PR DESCRIPTION
Trying to fix test_vm_sample, because it requires a environment variable WICHRUNTIME.